### PR TITLE
Update ssh-and-http documentation to remove some unnecessary steps and add a required variable

### DIFF
--- a/contrib/ssh-and-http.mkd
+++ b/contrib/ssh-and-http.mkd
@@ -15,13 +15,7 @@ Assumptions:
 
 Please adjust the instructions below to reflect your setup (users and paths).
 
-Edit your .gitolite.rc and add
-
-    $ENV{PATH} .= ":/opt/git/bin";
-
-at the very top (as described in `t/smart-http.root-setup`).
-
-Also add an option like this inside your "%RC = (" section:
+Add an option like this inside your "%RC = (" section:
     HTTP_ANON_USER  => 'gitweb',
 
 Next, check which document root your Apache's suexec accepts:
@@ -37,12 +31,9 @@ Next, check which document root your Apache's suexec accepts:
 
 We're interested in `AP_DOC_ROOT`, which is set to `/var/www` in our case.
 
-Create a `bin` and a `git` directory in `AP_DOC_ROOT`:
+Create a `bin` directory in `AP_DOC_ROOT`:
 
     install -d -m 0755 -o git -g git /var/www/bin
-    install -d -m 0755 -o www -g www /var/www/git
-
-`/var/www/git` is just a dummy directory used as Apache's document root (see below).
 
 Next, create a shell script inside `/var/www/bin` named `gitolite-suexec-wrapper.sh`,
 with mode **0700** and owned by user and group **git**. Add the following content:


### PR DESCRIPTION
The documentation on the ssh-and-http page is slightly incorrect.  A HTTP_ANON_USER variable is required in order to function, or else one gets this error:

[root@boris ~]# git clone http://git1.dmz.scl3.mozilla.com/git/testing.git
Cloning into 'testing'...
fatal: remote error: FATAL: invalid user ''

Additionally, with apache's ScriptAlias line, a '/var/www/git' directory is no longer required, so I removed references to that to make the documentation simpler.

I was also considering removing the $ENV{PATH}="newstuff" line reference because I got it working without that line, but I'm not sure if I will see unforeseen breakage because of it in the future.
